### PR TITLE
Implement Node.js bridge for Crestron

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # CrestronAnbindung
 
-Dieses Repository enthaelt einen einfachen Prototypen einer HTML5-Weboberflaeche zur Steuerung eines Crestron-Systems. 
+Dieses Repository enthaelt einen einfachen Prototypen einer HTML5-Weboberflaeche zur Steuerung eines Crestron-Systems.
+Zusätzlich ist eine Node.js-Anwendung enthalten, die als Brücke zwischen WebSocket-Clients
+und dem Crestron-System fungiert.
 
 ## Dateien
 
@@ -11,7 +13,16 @@ Dieses Repository enthaelt einen einfachen Prototypen einer HTML5-Weboberflaeche
 
 ## Verwendung
 
-1. Einen WebSocket-Server auf dem Crestron-System bereitstellen, der die Signale `Light_On`, `Volume_Level` und `Source_Select` annimmt.
+1. Abhängigkeiten installieren und den Node.js-Server starten:
+
+   ```bash
+   npm install
+   npm start
+   ```
+
+   Der Server öffnet einen WebSocket auf Port `8080` und stellt gleichzeitig eine TCP-Verbindung
+   zum Crestron-System unter `192.168.1.100:41794` her.
+
 2. In `script.js` ggf. die WebSocket-Adresse anpassen.
 3. Die Dateien auf einem Webserver bereitstellen oder in ein Crestron CH5-Projekt integrieren.
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "crestron-anbindung",
+  "version": "1.0.0",
+  "description": "WebSocket-TCP-Bridge für Crestron",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "ws": "^8.15.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,48 @@
+const WebSocket = require('ws');
+const net = require('net');
+
+const WS_PORT = 8080;
+const CRESTRON_HOST = '192.168.1.100';
+const CRESTRON_PORT = 41794;
+
+const wss = new WebSocket.Server({ port: WS_PORT }, () => {
+  console.log(`WebSocket-Server gestartet auf Port ${WS_PORT}`);
+});
+
+const clients = new Set();
+
+const crestron = net.createConnection({ host: CRESTRON_HOST, port: CRESTRON_PORT }, () => {
+  console.log(`TCP-Verbindung zu Crestron hergestellt: ${CRESTRON_HOST}:${CRESTRON_PORT}`);
+});
+
+crestron.on('data', data => {
+  console.log('Von Crestron empfangen:', data.toString());
+  for (const client of clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(data);
+    }
+  }
+});
+
+crestron.on('error', err => {
+  console.error('Crestron TCP-Fehler:', err.message);
+});
+
+crestron.on('close', () => {
+  console.log('TCP-Verbindung zu Crestron geschlossen');
+});
+
+wss.on('connection', ws => {
+  clients.add(ws);
+  console.log('WebSocket-Client verbunden');
+
+  ws.on('message', msg => {
+    console.log('Vom Client empfangen:', msg.toString());
+    crestron.write(msg);
+  });
+
+  ws.on('close', () => {
+    clients.delete(ws);
+    console.log('WebSocket-Client getrennt');
+  });
+});


### PR DESCRIPTION
## Summary
- add a `server.js` that connects WebSocket clients to the Crestron TCP port
- provide a `package.json` with the `ws` dependency and start script
- document usage of the new Node.js server in `README.md`

## Testing
- `npm install` *(fails: 403 Forbidden - registry access blocked)*
- `node server.js` *(fails: Cannot find module 'ws')*

------
https://chatgpt.com/codex/tasks/task_e_68653dd433c0832d8b69acaa82c396cb